### PR TITLE
fix find-gh-poc install in workflow

### DIFF
--- a/.github/workflows/collect_pocs.yml
+++ b/.github/workflows/collect_pocs.yml
@@ -1,9 +1,10 @@
+---
 name: Collect CVE PoCs
 
-on:
+'on':
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   build:
@@ -26,7 +27,8 @@ jobs:
       - name: Install ffuf and find-gh-poc
         run: |
           go install github.com/ffuf/ffuf/v2@latest
-          go install github.com/trickest/find-gh-poc@latest
+          git clone https://github.com/trickest/find-gh-poc.git /tmp/find-gh-poc
+          (cd /tmp/find-gh-poc && go install)
           echo "$GOBIN" >> $GITHUB_PATH
         env:
           GOBIN: /usr/local/bin
@@ -38,7 +40,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        run: python scripts/collect_pocs.py --output pocs --blacklist blacklist.txt
+        run: |
+          python scripts/collect_pocs.py \
+            --output pocs \
+            --blacklist blacklist.txt
 
       - name: Commit changes
         run: |


### PR DESCRIPTION
## Summary
- install find-gh-poc by cloning repo to avoid go module path mismatch
- clean up workflow yaml and wrap long lines for linting

## Testing
- `yamllint .github/workflows/collect_pocs.yml`

------
https://chatgpt.com/codex/tasks/task_e_68beaa243e7883338964185316caca10