### PR TITLE
Allow workflow to push results and process CVEs from 2020 onward

### DIFF
--- a/.github/workflows/collect_pocs.yml
+++ b/.github/workflows/collect_pocs.yml
@@ -6,6 +6,9 @@ name: Collect CVE PoCs
     - cron: '0 0 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -233,7 +233,6 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Collect CVE PoCs")
     parser.add_argument("--output", default="pocs", help="Output directory for markdown files")
     parser.add_argument("--blacklist", default="blacklist.txt", help="Blacklist file")
-    parser.add_argument("--limit", type=int, default=1000, help="Limit number of CVEs processed (for testing)")
     args = parser.parse_args()
 
     blacklist = load_blacklist(Path(args.blacklist))
@@ -248,7 +247,10 @@ def main() -> None:
         cves = parse_cves(repo)
 
     updated_files = []
-    for cve in list(cves.values())[: args.limit]:
+    for cve in cves.values():
+        year = int(cve.cve_id.split("-")[1])
+        if year < 2020:
+            continue
         check_references(cve)
         search_github(cve, token)
         search_sploitus(cve)


### PR DESCRIPTION
## Summary
- enable write permissions for GitHub Actions
- drop artificial CVE limit and skip entries prior to 2020

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68beb74065a88333a40ba2e99e4b3260