### PR TITLE
Limit PoC collection to 2025+ CVEs and enable workflow tracing

### DIFF
--- a/.github/workflows/collect_pocs.yml
+++ b/.github/workflows/collect_pocs.yml
@@ -9,6 +9,10 @@ name: Collect CVE PoCs
 permissions:
   contents: write
 
+defaults:
+  run:
+    shell: bash -x {0}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ repository and searches multiple sources for PoCs, including:
 * [Sploitus](https://sploitus.com)
 
 Results are written to year‑based markdown files under [`pocs/`](pocs/). Only
-CVEs with at least one PoC are stored. False positives can be filtered via the
-[`blacklist.txt`](blacklist.txt) file.
+CVEs from 2025 onward with at least one PoC are stored. False positives can be
+filtered via the [`blacklist.txt`](blacklist.txt) file.

--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -249,7 +249,7 @@ def main() -> None:
     updated_files = []
     for cve in cves.values():
         year = int(cve.cve_id.split("-")[1])
-        if year < 2020:
+        if year < 2025:  # Only process recent CVEs
             continue
         check_references(cve)
         search_github(cve, token)


### PR DESCRIPTION
## Summary
- process only CVEs from 2025 onward in collection script
- document the new scope in README
- enable `bash -x` tracing for workflow run steps

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`
- `python - <<'PY'\nimport yaml,sys\nwith open('.github/workflows/collect_pocs.yml') as f:\n    yaml.safe_load(f)\nprint('YAML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68c0596e9ca083338104f033fefe4a64