### PR TITLE
feat: speed up CVE collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,8 @@ repository and searches multiple sources for PoCs, including:
 * [Sploitus](https://sploitus.com)
 
 Results are written to year‑based markdown files under [`pocs/`](pocs/). Only
-CVEs from 2025 onward with at least one PoC are stored. False positives can be
-filtered via the [`blacklist.txt`](blacklist.txt) file.
+CVEs from 2025 onward with at least one PoC are stored by default. False
+positives can be filtered via the [`blacklist.txt`](blacklist.txt) file. The
+[`collect_pocs.py`](scripts/collect_pocs.py) helper performs a sparse clone of
+the CVE list repository to speed up execution and accepts additional options
+such as `--min-year` and `-v/--verbose` for finer control.

--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -27,7 +27,9 @@ added CVEs will be sent to the webhook.
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
+import logging
 import os
 import re
 import shutil
@@ -51,18 +53,55 @@ class CVE:
     pocs: Set[str] = field(default_factory=set)
 
 
-def run(cmd: List[str], cwd: Path | None = None) -> None:
-    """Run a subprocess and raise if it fails."""
-    subprocess.run(cmd, check=True, cwd=cwd)
+def run(cmd: List[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a subprocess and raise if it fails.
+
+    All executed commands are logged to aid troubleshooting when running in
+    automated environments such as GitHub Actions.
+    """
+    logging.debug("Running command: %s", " ".join(cmd))
+    return subprocess.run(cmd, check=check, cwd=cwd)
 
 
-def clone_cve_repo(dest: Path) -> Path:
-    """Clone cvelistV5 repository to ``dest``."""
+def clone_cve_repo(dest: Path, years: List[int]) -> Path:
+    """Clone cvelistV5 repository to ``dest`` using a sparse checkout.
+
+    Only the ``cves/<year>`` directories for the supplied years are checked
+    out. This dramatically reduces the number of files that need to be
+    transferred and written to disk.
+    """
     repo_path = dest / "cvelistV5"
     if repo_path.exists():
+        logging.info("Updating existing cvelistV5 repository")
         run(["git", "-C", str(repo_path), "pull", "--ff-only"])
     else:
-        run(["git", "clone", "--depth", "1", CVE_GIT_URL, str(repo_path)])
+        logging.info("Cloning cvelistV5 repository")
+        run([
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            "--sparse",
+            CVE_GIT_URL,
+            str(repo_path),
+        ])
+        if years:
+            paths = [f"cves/{y}" for y in years]
+            logging.debug("Sparse checkout paths: %s", paths)
+            result = run([
+                "git",
+                "-C",
+                str(repo_path),
+                "sparse-checkout",
+                "set",
+                "--no-cone",
+                *paths,
+            ], check=False)
+            if result.returncode != 0:
+                logging.warning(
+                    "Sparse checkout failed; falling back to full repository"
+                )
     return repo_path
 
 
@@ -70,15 +109,32 @@ def parse_cves(repo_path: Path) -> Dict[str, CVE]:
     """Parse CVE JSON files from the repository."""
     cves: Dict[str, CVE] = {}
     cve_dir = repo_path / "cves"
+    logging.info("Scanning CVE JSON files under %s", cve_dir)
+    count = 0
     # Only consider individual CVE JSON files. The repository also contains
     # summary files such as year indexes which should be ignored.
     for json_path in cve_dir.rglob("CVE-*.json"):
         with open(json_path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
         cve_id = data["cveMetadata"]["cveId"]
-        description = data.get("containers", {}).get("cna", {}).get("descriptions", [{}])[0].get("value", "")
-        refs = [r.get("url") for r in data.get("containers", {}).get("cna", {}).get("references", []) if r.get("url")]
+        description = (
+            data.get("containers", {})
+            .get("cna", {})
+            .get("descriptions", [{}])[0]
+            .get("value", "")
+        )
+        refs = [
+            r.get("url")
+            for r in data.get("containers", {})
+            .get("cna", {})
+            .get("references", [])
+            if r.get("url")
+        ]
         cves[cve_id] = CVE(cve_id=cve_id, description=description, references=refs)
+        count += 1
+        if count % 1000 == 0:
+            logging.info("Parsed %d CVEs", count)
+    logging.info("Finished parsing %d CVEs", count)
     return cves
 
 
@@ -233,7 +289,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Collect CVE PoCs")
     parser.add_argument("--output", default="pocs", help="Output directory for markdown files")
     parser.add_argument("--blacklist", default="blacklist.txt", help="Blacklist file")
+    parser.add_argument("--min-year", type=int, default=2025, help="Minimum CVE year to process")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
 
     blacklist = load_blacklist(Path(args.blacklist))
     token = os.getenv("GITHUB_TOKEN")
@@ -242,21 +305,24 @@ def main() -> None:
     base = Path(args.output)
     base.mkdir(parents=True, exist_ok=True)
 
+    years = list(range(args.min_year, dt.datetime.now().year + 1))
     with tempfile.TemporaryDirectory() as tmpdir:
-        repo = clone_cve_repo(Path(tmpdir))
+        repo = clone_cve_repo(Path(tmpdir), years)
         cves = parse_cves(repo)
 
-    updated_files = []
+    updated_files: List[str] = []
     for cve in cves.values():
         year = int(cve.cve_id.split("-")[1])
-        if year < 2025:  # Only process recent CVEs
+        if year < args.min_year:
             continue
+        logging.debug("Processing %s", cve.cve_id)
         check_references(cve)
         search_github(cve, token)
         search_sploitus(cve)
         search_find_gh_poc(cve, token)
 
         if write_markdown(base, cve, blacklist):
+            logging.info("Updated %s", cve.cve_id)
             updated_files.append(cve.cve_id)
 
     if webhook and updated_files:


### PR DESCRIPTION
## Summary
- clone only recent CVE directories with sparse checkout to reduce runtime
- add `--min-year` and `-v/--verbose` flags with structured logging
- document new options in README

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c1472057448333b561a26f03d8c8aa