### PR TITLE
feat: commit each CVE update and track progress

### DIFF
--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -35,6 +35,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Set
@@ -161,8 +162,9 @@ def ffuf_scan(url: str) -> List[str]:
         except Exception:
             return []
 
-def check_references(cve: CVE) -> None:
+def check_references(cve: CVE) -> Set[str]:
     """Inspect references for PoC indicators."""
+    pocs: Set[str] = set()
     for ref in cve.references:
         try:
             resp = requests.get(ref, timeout=10)
@@ -170,33 +172,39 @@ def check_references(cve: CVE) -> None:
         except Exception:
             continue
         if POC_REGEX.search(text) or POC_REGEX.search(ref):
-            cve.pocs.add(ref)
+            pocs.add(ref)
         for fuzz in ffuf_scan(ref):
-            cve.pocs.add(fuzz)
+            pocs.add(fuzz)
 
         # TODO: integrate ffuf fuzzing against references with custom keyword
         # lists for more advanced discovery.
+    return pocs
 
-def search_github(cve: CVE, token: str | None) -> None:
+def search_github(cve: CVE, token: str | None) -> Set[str]:
     """Search GitHub for repositories mentioning the CVE."""
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     query = f"{cve.cve_id} poc"  # bias towards PoC repositories
     url = "https://api.github.com/search/repositories"
+    results: Set[str] = set()
     try:
         resp = requests.get(url, params={"q": query}, headers=headers, timeout=10)
         data = resp.json()
         for item in data.get("items", [])[:5]:
-            cve.pocs.add(item.get("html_url"))
+            href = item.get("html_url")
+            if href:
+                results.add(href)
     except Exception:
         pass
+    return results
 
 
-def search_find_gh_poc(cve: CVE, token: str | None) -> None:
+def search_find_gh_poc(cve: CVE, token: str | None) -> Set[str]:
     """Use find-gh-poc CLI to locate PoCs on GitHub."""
+    results: Set[str] = set()
     if not shutil.which("find-gh-poc"):
-        return
+        return results
     cmd = ["find-gh-poc", cve.cve_id]
     if token:
         cmd.extend(["--token", token])
@@ -205,12 +213,14 @@ def search_find_gh_poc(cve: CVE, token: str | None) -> None:
         for line in output.splitlines():
             line = line.strip()
             if line.startswith("http"):
-                cve.pocs.add(line)
+                results.add(line)
     except Exception:
         pass
+    return results
 
-def search_sploitus(cve: CVE) -> None:
+def search_sploitus(cve: CVE) -> Set[str]:
     """Query the Sploitus API for exploits."""
+    results: Set[str] = set()
     try:
         resp = requests.post(
             "https://sploitus.com/search",
@@ -221,9 +231,24 @@ def search_sploitus(cve: CVE) -> None:
         for exploit in data.get("exploits", []):
             href = exploit.get("href")
             if href:
-                cve.pocs.add(href)
+                results.add(href)
     except Exception:
         pass
+    return results
+
+
+def load_processed(path: Path) -> Set[str]:
+    """Load previously processed CVE IDs."""
+    if not path.exists():
+        return set()
+    with open(path, "r", encoding="utf-8") as fh:
+        return {line.strip() for line in fh if line.strip()}
+
+
+def append_processed(path: Path, cve_id: str) -> None:
+    """Append a processed CVE ID to the state file."""
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{cve_id}\n")
 
 
 def load_blacklist(path: Path) -> List[str]:
@@ -254,7 +279,7 @@ def read_existing_markdown(path: Path) -> Set[str]:
     return pocs
 
 
-def write_markdown(base: Path, cve: CVE, blacklist: List[str]) -> bool:
+def write_markdown(base: Path, cve: CVE, blacklist: List[str]) -> Path | None:
     year_dir = base / cve.cve_id.split("-")[1]
     year_dir.mkdir(parents=True, exist_ok=True)
     md_path = year_dir / f"{cve.cve_id}.md"
@@ -263,10 +288,10 @@ def write_markdown(base: Path, cve: CVE, blacklist: List[str]) -> bool:
     new_pocs = filter_blacklist(cve.pocs, blacklist)
     updated = existing.union(new_pocs)
     if not updated:
-        return False
+        return None
 
     if existing == updated:
-        return False
+        return None
 
     with open(md_path, "w", encoding="utf-8") as fh:
         fh.write(f"# {cve.cve_id}\n\n")
@@ -275,7 +300,7 @@ def write_markdown(base: Path, cve: CVE, blacklist: List[str]) -> bool:
         fh.write("## PoCs\n")
         for poc in sorted(updated):
             fh.write(f"- {poc}\n")
-    return True
+    return md_path
 
 
 def send_discord(webhook: str, message: str) -> None:
@@ -285,11 +310,52 @@ def send_discord(webhook: str, message: str) -> None:
         pass
 
 
+def git_commit(repo_root: Path, md_path: Path, cve_id: str) -> None:
+    """Commit the updated markdown file to the repository."""
+    rel_path = md_path.relative_to(repo_root)
+    run(["git", "add", str(rel_path)], cwd=repo_root)
+    run(["git", "commit", "-m", f"[skip ci] Update PoCs for {cve_id}"], cwd=repo_root)
+
+
+def log_progress(idx: int, total: int, updated: int, start: dt.datetime) -> None:
+    """Log current progress and estimated completion time."""
+    elapsed = dt.datetime.now() - start
+    rate = idx / elapsed.total_seconds() if elapsed.total_seconds() else 0
+    remaining = total - idx
+    pct = (idx / total) * 100 if total else 0
+    if rate:
+        eta = dt.datetime.now() + dt.timedelta(seconds=remaining / rate)
+        eta_str = eta.strftime("%H:%M:%S")
+    else:
+        eta_str = "unknown"
+    logging.info(
+        "Progress: %d/%d (%.1f%%) processed (%d updated). %d remaining. ETA %s",
+        idx,
+        total,
+        pct,
+        updated,
+        remaining,
+        eta_str,
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Collect CVE PoCs")
     parser.add_argument("--output", default="pocs", help="Output directory for markdown files")
     parser.add_argument("--blacklist", default="blacklist.txt", help="Blacklist file")
     parser.add_argument("--min-year", type=int, default=2025, help="Minimum CVE year to process")
+    parser.add_argument(
+        "--state-file",
+        default=Path(__file__).resolve().parents[1] / ".cache" / "processed.txt",
+        type=Path,
+        help="File used to track processed CVEs",
+    )
+    parser.add_argument(
+        "--cvelist-dir",
+        default=Path(__file__).resolve().parents[1] / ".cache",
+        type=Path,
+        help="Directory to cache the cvelistV5 repository",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
@@ -306,24 +372,44 @@ def main() -> None:
     base.mkdir(parents=True, exist_ok=True)
 
     years = list(range(args.min_year, dt.datetime.now().year + 1))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        repo = clone_cve_repo(Path(tmpdir), years)
-        cves = parse_cves(repo)
+    args.cvelist_dir.mkdir(parents=True, exist_ok=True)
+    args.state_file.parent.mkdir(parents=True, exist_ok=True)
+    repo = clone_cve_repo(args.cvelist_dir, years)
+    cves = parse_cves(repo)
 
+    processed = load_processed(args.state_file)
+    cve_list = [
+        c
+        for c in cves.values()
+        if int(c.cve_id.split("-")[1]) >= args.min_year and c.cve_id not in processed
+    ]
+    total = len(cve_list)
+    logging.info("Processing %d CVEs (%d already processed)", total, len(processed))
+    start = dt.datetime.now()
+    repo_root = Path(__file__).resolve().parents[1]
     updated_files: List[str] = []
-    for cve in cves.values():
-        year = int(cve.cve_id.split("-")[1])
-        if year < args.min_year:
-            continue
-        logging.debug("Processing %s", cve.cve_id)
-        check_references(cve)
-        search_github(cve, token)
-        search_sploitus(cve)
-        search_find_gh_poc(cve, token)
 
-        if write_markdown(base, cve, blacklist):
-            logging.info("Updated %s", cve.cve_id)
-            updated_files.append(cve.cve_id)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        for idx, cve in enumerate(cve_list, start=1):
+            logging.debug("Processing %s", cve.cve_id)
+            futures = [
+                pool.submit(check_references, cve),
+                pool.submit(search_github, cve, token),
+                pool.submit(search_sploitus, cve),
+                pool.submit(search_find_gh_poc, cve, token),
+            ]
+            for fut in futures:
+                cve.pocs.update(fut.result())
+
+            md_path = write_markdown(base, cve, blacklist)
+            if md_path:
+                logging.info("Updated %s", cve.cve_id)
+                git_commit(repo_root, md_path, cve.cve_id)
+                updated_files.append(cve.cve_id)
+
+            append_processed(args.state_file, cve.cve_id)
+            if idx % 100 == 0 or md_path:
+                log_progress(idx, total, len(updated_files), start)
 
     if webhook and updated_files:
         send_discord(webhook, f"Updated CVEs with PoCs: {', '.join(updated_files)}")


### PR DESCRIPTION
## Summary
- commit updated CVE PoC files individually with `[skip ci]` commit messages
- log progress with percentage, totals, and ETA
- reuse a thread pool across CVEs to avoid per-item startup overhead

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`
- `python scripts/collect_pocs.py --output pocs --blacklist blacklist.txt --min-year 3000 --cvelist-dir .cache-test --state-file .cache-test/state.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c15a13ec288333b6e8a659ca56c15b