### PR TITLE
fix: handle absolute PoC paths

### DIFF
--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -312,6 +312,7 @@ def send_discord(webhook: str, message: str) -> None:
 
 def git_commit(repo_root: Path, md_path: Path, cve_id: str) -> None:
     """Commit the updated markdown file to the repository."""
+    md_path = md_path.resolve()
     rel_path = md_path.relative_to(repo_root)
     run(["git", "add", str(rel_path)], cwd=repo_root)
     run(["git", "commit", "-m", f"[skip ci] Update PoCs for {cve_id}"], cwd=repo_root)
@@ -368,7 +369,10 @@ def main() -> None:
     token = os.getenv("GITHUB_TOKEN")
     webhook = os.getenv("DISCORD_WEBHOOK_URL")
 
+    repo_root = Path(__file__).resolve().parents[1]
     base = Path(args.output)
+    if not base.is_absolute():
+        base = repo_root / base
     base.mkdir(parents=True, exist_ok=True)
 
     years = list(range(args.min_year, dt.datetime.now().year + 1))
@@ -386,7 +390,6 @@ def main() -> None:
     total = len(cve_list)
     logging.info("Processing %d CVEs (%d already processed)", total, len(processed))
     start = dt.datetime.now()
-    repo_root = Path(__file__).resolve().parents[1]
     updated_files: List[str] = []
 
     with ThreadPoolExecutor(max_workers=4) as pool:


### PR DESCRIPTION
## Summary
- ensure PoC output directory is resolved relative to repository root
- resolve paths before committing markdown files to avoid `Path.relative_to` errors

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c1a711fbe083339a1d54d978fc8e7e