### PR TITLE
fix: handle inline comments in PoC list

### DIFF
--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -258,6 +258,40 @@ def load_blacklist(path: Path) -> List[str]:
         return [line.strip() for line in fh if line.strip() and not line.startswith("#")]
 
 
+def get_comments(line: str) -> str:
+    """Extract an inline comment from a markdown list entry.
+
+    The markdown files produced by this project allow contributors to append
+    clarifying notes after a PoC URL using the ``#`` character, e.g.::
+
+        - https://example.com/poc.py # requires authentication
+
+    A naive ``str.split('#')`` would incorrectly split URLs that contain a
+    fragment identifier (``#section``).  To avoid this the comment is only
+    treated as such when the ``#`` is preceded by whitespace.
+
+    Parameters
+    ----------
+    line:
+        The raw line from the markdown file (without the leading ``-``).
+
+    Returns
+    -------
+    str
+        The trailing comment text or an empty string if no comment is present.
+    """
+
+    # Iterate through the characters so we can inspect the preceding one. This
+    # allows us to distinguish between ``#`` used for URL fragments and genuine
+    # comments which are typically preceded by whitespace.
+    for idx, char in enumerate(line):
+        if char == "#" and (idx == 0 or line[idx - 1].isspace()):
+            # Return everything after the ``#`` while trimming surrounding
+            # whitespace.  Multiple ``#`` in the comment are preserved.
+            return line[idx + 1 :].strip()
+    return ""
+
+
 def filter_blacklist(pocs: Iterable[str], blacklist: List[str]) -> List[str]:
     result = []
     for poc in pocs:
@@ -274,8 +308,15 @@ def read_existing_markdown(path: Path) -> Set[str]:
         for line in fh:
             line = line.strip()
             if line.startswith("- "):
-                url = line[2:].strip()
-                pocs.add(url)
+                entry = line[2:].strip()
+                # Strip any inline comment so only the URL is considered when
+                # comparing PoCs.  This prevents comment text from being treated
+                # as part of the URL, which would otherwise result in duplicate
+                # entries.
+                comment = get_comments(entry)
+                if comment:
+                    entry = entry[: entry.index("#")].rstrip()
+                pocs.add(entry)
     return pocs
 
 


### PR DESCRIPTION
## Summary
- add `get_comments` helper to parse markdown PoC entries without truncating URLs containing fragments
- strip inline comments when reading existing markdown to avoid duplicate URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a967a8b883339959d775a2cfcc92