### PR TITLE
fix: configure git identity before committing

### DIFF
--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -355,6 +355,27 @@ def git_commit(repo_root: Path, md_path: Path, cve_id: str) -> None:
     """Commit the updated markdown file to the repository."""
     md_path = md_path.resolve()
     rel_path = md_path.relative_to(repo_root)
+    # Ensure a git identity is configured. GitHub Actions runners may lack
+    # ``user.name`` and ``user.email`` which causes ``git commit`` to fail.
+    result = run(["git", "config", "user.email"], cwd=repo_root, check=False)
+    if result.returncode != 0:
+        run(
+            [
+                "git",
+                "config",
+                "user.email",
+                "github-actions@users.noreply.github.com",
+            ],
+            cwd=repo_root,
+        )
+    result = run(["git", "config", "user.name"], cwd=repo_root, check=False)
+    if result.returncode != 0:
+        run([
+            "git",
+            "config",
+            "user.name",
+            "github-actions",
+        ], cwd=repo_root)
     run(["git", "add", str(rel_path)], cwd=repo_root)
     run(["git", "commit", "-m", f"[skip ci] Update PoCs for {cve_id}"], cwd=repo_root)
 


### PR DESCRIPTION
## Summary
- ensure `collect_pocs.py` configures a default git user identity before committing

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c1abd9eda483338d0fb08fe821912d