### PR TITLE
Add CVE severity and ensure rebasing before push

### DIFF
--- a/pocs/2025/CVE-2025-0195.md
+++ b/pocs/2025/CVE-2025-0195.md
@@ -2,5 +2,7 @@
 
 A vulnerability was found in code-projects Point of Sales and Inventory Management System 1.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file /user/del_product.php. The manipulation of the argument id leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used.
 
+**Severity:** MEDIUM
+
 ## PoCs
 - https://gist.github.com/Masamuneee/1ac717728823d58ef365a418c8f39810

--- a/scripts/collect_pocs.py
+++ b/scripts/collect_pocs.py
@@ -56,6 +56,7 @@ class CVE:
     cve_id: str
     description: str
     references: List[str]
+    severity: str | None = None
     pocs: Set[str] = field(default_factory=set)
 
 
@@ -136,7 +137,39 @@ def parse_cves(repo_path: Path) -> Dict[str, CVE]:
             .get("references", [])
             if r.get("url")
         ]
-        cves[cve_id] = CVE(cve_id=cve_id, description=description, references=refs)
+        metrics = (
+            data.get("containers", {})
+            .get("cna", {})
+            .get("metrics", [])
+        )
+        severity: str | None = None
+        for metric in metrics:
+            for key in ("cvssV4_0", "cvssV3_1", "cvssV3_0", "cvssV2_0"):
+                details = metric.get(key)
+                if not details:
+                    continue
+                severity = details.get("baseSeverity")
+                if not severity and key == "cvssV2_0":
+                    score = details.get("baseScore")
+                    if isinstance(score, (int, float)):
+                        if score >= 7.0:
+                            severity = "HIGH"
+                        elif score >= 4.0:
+                            severity = "MEDIUM"
+                        elif score > 0:
+                            severity = "LOW"
+                        else:
+                            severity = "NONE"
+                if severity:
+                    break
+            if severity:
+                break
+        cves[cve_id] = CVE(
+            cve_id=cve_id,
+            description=description,
+            references=refs,
+            severity=severity,
+        )
         count += 1
         if count % 1000 == 0:
             logging.info("Parsed %d CVEs", count)
@@ -315,6 +348,8 @@ def write_markdown(base: Path, cve: CVE, blacklist: List[str]) -> Path | None:
         fh.write(f"# {cve.cve_id}\n\n")
         if cve.description:
             fh.write(f"{cve.description}\n\n")
+        if cve.severity:
+            fh.write(f"**Severity:** {cve.severity}\n\n")
         fh.write("## PoCs\n")
         for poc in sorted(updated):
             fh.write(f"- {poc}\n")
@@ -355,11 +390,17 @@ def git_commit(repo_root: Path, md_path: Path, cve_id: str) -> None:
         ], cwd=repo_root)
     run(["git", "add", str(rel_path)], cwd=repo_root)
     run(["git", "commit", "-m", f"[skip ci] Update PoCs for {cve_id}"], cwd=repo_root)
-    # Rebase local commits in case the remote branch advanced while this script
-    # was running. This avoids push failures when other processes update the
-    # repository concurrently.
-    run(["git", "pull", "--rebase"], cwd=repo_root, check=False)
-    run(["git", "push"], cwd=repo_root)
+    # Always rebase before pushing in case the remote branch advanced while
+    # this script was running.  Retry the push a few times to handle races with
+    # other processes updating the repository concurrently.
+    for _ in range(3):
+        run(["git", "pull", "--rebase"], cwd=repo_root, check=False)
+        result = run(["git", "push"], cwd=repo_root, check=False)
+        if result.returncode == 0:
+            break
+    else:
+        # If all attempts failed, surface the error to aid troubleshooting.
+        result.check_returncode()
 
 
 def log_progress(idx: int, total: int, updated: int, start: dt.datetime) -> None:


### PR DESCRIPTION
## Summary
- Include CVE severity in generated markdown reports
- Parse severity from CVE JSON data
- Retry pushes with automatic `git pull --rebase` to avoid conflicts

## Testing
- `python -m py_compile scripts/collect_pocs.py`
- `python scripts/collect_pocs.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68c3d77d82f8833391ea75591578766f